### PR TITLE
Experimental/sonata-validation: using synapse xyz coords to determine the synapse locations in Arbor

### DIFF
--- a/data/main.py
+++ b/data/main.py
@@ -5,15 +5,27 @@ import subprocess as sp
 import site
 import sys
 import re
+from argparse import ArgumentParser
 
-# configuration
-have_timing = False
-have_stats = False
-have_venv = False
-have_mpi = False
-have_gpu = False
-have_plots = False
+# process arguments
+ap = ArgumentParser()
+ap.add_argument('-e', '--use-venv',  action='store_true', default=False, help='Setup and use virtual env.')
+ap.add_argument('-s', '--use-stats', action='store_true', default=False, help='Collect and print simulation statistics.')
+ap.add_argument('-t', '--use-times', action='store_true', default=False, help='Collect and print simulation timings.')
+ap.add_argument('-m', '--use-mpi',   action='store_true', default=False, help='Use MPI.')
+ap.add_argument('-g', '--use-gpu',   action='store_true', default=False, help='Use GPU.')
+ap.add_argument('-p', '--plot',      action='store_true', default=False, help='Plot data in addition to storing.')
 
+args = ap.parse_args()
+
+have_timing = args.t
+have_stats = args.s
+have_venv = args.e
+have_mpi = args.m
+have_gpu = args.g
+have_plots = args.p
+
+# version meta data
 cur_version = [0, 10, 0]
 nxt_version = [0, 11, 0]
 cur_version_str = f"{cur_version[0]}.{cur_version[1]}.{cur_version[2]}"

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -128,7 +128,7 @@ impl Decor {
         acc.push_str(
             "(arbor-component
   (meta-data
-    (version \"0.9-dev\"))
+    (version \"0.10-dev\"))
       (decor",
         );
         if let Some(v) = self.defaults.cm {
@@ -193,6 +193,13 @@ impl Decor {
             },
         ) in self.mechanisms.iter()
         {
+            // NOTE This is a nasty hack, but required for automatic Nernst
+            // setting in the main script!
+            if let Some(v) = parameters.get("gbar") {
+                if *v == 0.0 {
+                    continue;
+                }
+            }
             let mut mech = name.to_string();
             let mut sep = '/';
             for (k, v) in globals {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -13,8 +13,8 @@ use serde::Serialize;
 type ConnectionData = (usize, usize, usize, f64, f64);
 /// (location, variable, tag)
 type ProbeData = (Option<String>, String, usize);
-/// (location, mech, params, tag)
-type SynapseData = (String, String, Map<String, f64>, usize);
+/// (x, y, z, mech, params, tag)
+type SynapseData = (f64, f64, f64, String, Map<String, f64>, usize);
 /// (location, delay, duration, current, tag)
 type IClampData = (String, f64, f64, f64, usize);
 
@@ -145,11 +145,7 @@ impl Bundle {
                         ));
                         let mech = edge.mech.as_ref().ok_or(anyhow!("Edge has no mechanism"))?;
                         let mech = fudge_synapse_dynamics(mech);
-                        let loc = format!(
-                            "(on-components {} (segment {}))",
-                            edge.target.1, edge.target.0
-                        );
-                        syn.push((loc, mech, edge.dynamics.clone(), ix));
+                        syn.push((edge.target.0, edge.target.1, edge.target.2, mech, edge.dynamics.clone(), ix));
                     }
                     incoming_connections.insert(gid, inc);
                     synapses.insert(gid, syn);

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -508,7 +508,7 @@ impl EdgeList {
 pub struct Edge {
     pub src_gid: u64,
     pub source: (u64, f64),
-    pub target: (u64, f64),
+    pub target: (f64, f64, f64),
     pub mech: Option<String>,
     pub delay: f64,
     pub weight: f64,
@@ -1050,9 +1050,9 @@ impl Simulation {
                         None
                     };
 
-                    let tgt_pos = if let Some(ds) = edge_group.custom.get("afferent_swc_pos") {
+                    let tgt_pos_x = if let Some(ds) = edge_group.custom.get("afferent_section_xcoords") {
                         ds[group_index]
-                    } else if let Some(s) = ty.attributes.get("afferent_swc_pos") {
+                    } else if let Some(s) = ty.attributes.get("afferent_section_xcoords") {
                         if let Attribute::Float(s) = s {
                             *s
                         } else {
@@ -1062,12 +1062,12 @@ impl Simulation {
                                 );
                         }
                     } else {
-                        0.5 // default to centering
+                        0.0 // default to soma location
                     };
 
-                    let tgt_id = if let Some(ds) = edge_group.custom.get("afferent_swc_id") {
+                    let tgt_pos_y = if let Some(ds) = edge_group.custom.get("afferent_section_ycoords") {
                         ds[group_index]
-                    } else if let Some(s) = ty.attributes.get("afferent_swc_id") {
+                    } else if let Some(s) = ty.attributes.get("afferent_section_ycoords") {
                         if let Attribute::Float(s) = s {
                             *s
                         } else {
@@ -1077,8 +1077,23 @@ impl Simulation {
                                 );
                         }
                     } else {
-                        0.0 // default to first (=soma?)
-                    } as u64;
+                        0.0 // default to soma location
+                    };
+
+                    let tgt_pos_z = if let Some(ds) = edge_group.custom.get("afferent_section_zcoords") {
+                        ds[group_index]
+                    } else if let Some(s) = ty.attributes.get("afferent_section_zcoords") {
+                        if let Attribute::Float(s) = s {
+                            *s
+                        } else {
+                            bail!(
+                                    "Edge type {type_id} in population {} has non-numeric segment position",
+                                    edge_population.name
+                                );
+                        }
+                    } else {
+                        0.0 // default to soma location
+                    };
 
                     let src_pos = if let Some(ds) = edge_group.custom.get("efferent_swc_pos") {
                         ds[group_index]
@@ -1122,7 +1137,7 @@ impl Simulation {
                     incoming_edges.push(Edge {
                         src_gid,
                         source: (src_id, src_pos),
-                        target: (tgt_id, tgt_pos),
+                        target: (tgt_pos_x, tgt_pos_y, tgt_pos_z),
                         mech,
                         delay,
                         weight,

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -1062,7 +1062,10 @@ impl Simulation {
                                 );
                         }
                     } else {
-                        0.0 // default to soma location
+                        bail!(
+                                "[UNSUPPORTED] Edge type {type_id} in population {} is missing the `x` coordinates for the target segments. (x,y,z) coordinates of traget segmemnts are required for synapse placement.",
+                                edge_population.name
+                                );
                     };
 
                     let tgt_pos_y = if let Some(ds) = edge_group.custom.get("afferent_section_ycoords") {
@@ -1077,7 +1080,10 @@ impl Simulation {
                                 );
                         }
                     } else {
-                        0.0 // default to soma location
+                        bail!(
+                                "[UNSUPPORTED] Edge type {type_id} in population {} is missing the `y` coordinates for the target segments. (x,y,z) coordinates of traget segmemnts are required for synapse placement.",
+                                edge_population.name
+                                );
                     };
 
                     let tgt_pos_z = if let Some(ds) = edge_group.custom.get("afferent_section_zcoords") {
@@ -1092,7 +1098,10 @@ impl Simulation {
                                 );
                         }
                     } else {
-                        0.0 // default to soma location
+                        bail!(
+                                "[UNSUPPORTED] Edge type {type_id} in population {} is missing the `z` coordinates for the target segments. (x,y,z) coordinates of traget segmemnts are required for synapse placement.",
+                                edge_population.name
+                                );
                     };
 
                     let src_pos = if let Some(ds) = edge_group.custom.get("efferent_swc_pos") {


### PR DESCRIPTION
Replaces the use of target `afferent_swc_pos | id` for the exact `xyz` synapse coordinates and finds the closest location to this point in the morphology tree to place the synapse. It assumes that synapse coordinates are stored in the SONATA files as `afferent_section_xcoords`, `afferent_section_ycoords`, and `afferent_section_zcoords`.

Note: includes commits 1187dc6fef2594a04750096d759eb6e64bfe05c7 and 0da7eea3ea794bf74b1be560cd9000c6ca1edc8b from #1.